### PR TITLE
fixed for URI is not hierarchical(issue found on jdk 11)

### DIFF
--- a/dsm/src/main/java/com/github/mfatihercik/dsb/resource/FileSystemResourceAccessor.java
+++ b/dsm/src/main/java/com/github/mfatihercik/dsb/resource/FileSystemResourceAccessor.java
@@ -3,6 +3,7 @@ package com.github.mfatihercik.dsb.resource;
 import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URI;
 import java.net.URLClassLoader;
 import java.util.HashSet;
 import java.util.Set;
@@ -51,7 +52,11 @@ public class FileSystemResourceAccessor extends AbstractResourceAccessor {
     @Override
     protected void addRootPath(URL path) {
         try {
-            File pathAsFile = new File(path.toURI());
+            URI uri = path.toURI();
+            if(uri.isOpaque()) {
+                return;
+            }
+            File pathAsFile = new File(uri);
 
             for (File fileSystemRoot : File.listRoots()) {
                 if (pathAsFile.equals(fileSystemRoot)) { //don't include root


### PR DESCRIPTION
```
java.lang.IllegalArgumentException: URI is not hierarchical
	at java.base/java.io.File.<init>(File.java:418)
	at com.github.mfatihercik.dsb.resource.FileSystemResourceAccessor.addRootPath(FileSystemResourceAccessor.java:54)
	at com.github.mfatihercik.dsb.resource.AbstractResourceAccessor.init(AbstractResourceAccessor.java:39)
	at com.github.mfatihercik.dsb.resource.FileSystemResourceAccessor.init(FileSystemResourceAccessor.java:47)
	at com.github.mfatihercik.dsb.resource.FileSystemResourceAccessor.<init>(FileSystemResourceAccessor.java:27)
	at com.github.mfatihercik.dsb.configloader.AbstractConfigLoader.setResourceAccessor(AbstractConfigLoader.java:89)
	at com.github.mfatihercik.dsb.configloader.AbstractConfigLoader.<init>(AbstractConfigLoader.java:32)
	at com.github.mfatihercik.dsb.configloader.YamlConfigLoaderStrategy.<init>(YamlConfigLoaderStrategy.java:11)
	at com.github.mfatihercik.dsb.DSMBuilder.create(DSMBuilder.java:99)
	at com.github.mfatihercik.dsb.DSMBuilder.create(DSMBuilder.java:93)
```